### PR TITLE
fix(sec): upgrade org.apache.storm:storm-kafka-client to 1.2.3

### DIFF
--- a/code/Storm/storm-redis-integration/pom.xml
+++ b/code/Storm/storm-redis-integration/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0</version>
 
     <properties>
-        <storm.version>1.2.2</storm.version>
+        <storm.version>1.2.3</storm.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.storm:storm-kafka-client 1.2.2
- [CVE-2018-11779](https://www.oscs1024.com/hd/CVE-2018-11779)


### What did I do？
Upgrade org.apache.storm:storm-kafka-client from 1.2.2 to 1.2.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS