### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.3.19

### DIFF
--- a/code/Phoenix/spring-mybatis-phoenix/pom.xml
+++ b/code/Phoenix/spring-mybatis-phoenix/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>spring-mybatis-phoenix</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
-        <spring-base-version>5.1.6.RELEASE</spring-base-version>
+        <spring-base-version>5.3.19</spring-base-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 5.1.6.RELEASE
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 5.1.6.RELEASE to 5.3.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS