### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-hdfs to 3.3.2

### DIFF
--- a/code/Storm/storm-hdfs-integration/pom.xml
+++ b/code/Storm/storm-hdfs-integration/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
-            <version>2.6.0-cdh5.15.2</version>
+            <version>3.3.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-hdfs 2.6.0-cdh5.15.2
- [CVE-2018-1296](https://www.oscs1024.com/hd/CVE-2018-1296)


### What did I do？
Upgrade org.apache.hadoop:hadoop-hdfs from 2.6.0-cdh5.15.2 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS