### PR TITLE
fix(sec): upgrade org.apache.zookeeper:zookeeper to 3.5.5

### DIFF
--- a/code/Zookeeper/curator/pom.xml
+++ b/code/Zookeeper/curator/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.13</version>
+            <version>3.5.5</version>
         </dependency>
         <!--单元测试相关依赖-->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.zookeeper:zookeeper 3.4.13
- [CVE-2019-0201](https://www.oscs1024.com/hd/CVE-2019-0201)


### What did I do？
Upgrade org.apache.zookeeper:zookeeper from 3.4.13 to 3.5.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS