### PR TITLE
fix(sec): upgrade junit:junit to 4.13.1

### DIFF
--- a/code/Hadoop/hdfs-java-api/pom.xml
+++ b/code/Hadoop/hdfs-java-api/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/code/Hbase/hbase-java-api-1.x/pom.xml
+++ b/code/Hbase/hbase-java-api-1.x/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/code/Hbase/hbase-java-api-2.x/pom.xml
+++ b/code/Hbase/hbase-java-api-2.x/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/code/Phoenix/spring-mybatis-phoenix/pom.xml
+++ b/code/Phoenix/spring-mybatis-phoenix/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/code/Zookeeper/curator/pom.xml
+++ b/code/Zookeeper/curator/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in junit:junit 4.12
- [CVE-2020-15250](https://www.oscs1024.com/hd/CVE-2020-15250)


### What did I do？
Upgrade junit:junit from 4.12 to 4.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS